### PR TITLE
Fix golint in GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Check for format and lint issues
       run: |
         test -z $(gofmt -s -d -l .) # see https://github.com/golang/go/issues/24230
-        test -z $(golint ./...)
+        test -z "$(golint ./...)"
 
     - name: Check imports
       run: goimports -l .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,10 +34,11 @@ jobs:
 
     - name: Check for format and lint issues
       run: |
+        # see https://github.com/golang/go/issues/24230
         fmtcode="$(gofmt -s -d -l .)"
-        echo $fmtcode && test -z $fmtcode # see https://github.com/golang/go/issues/24230
+        echo $fmtcode && test -z "$fmtcode"
         lintcode="$(golint ./...)"
-        echo $lintcode && test -z $lintcode
+        echo $lintcode && test -z "$lintcode"
 
     - name: Check imports
       run: goimports -l .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Check for format and lint issues
       run: |
         test -z $(gofmt -s -d -l .) # see https://github.com/golang/go/issues/24230
-        test -z "$(golint ./...)"
+        lint="$(golint ./...)" && test -z $lint
 
     - name: Check imports
       run: goimports -l .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Check for format and lint issues
       run: |
         test -z $(gofmt -s -d -l .) # see https://github.com/golang/go/issues/24230
-        golint ./...
+        test -z $(golint ./...)
 
     - name: Check imports
       run: goimports -l .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,8 +34,10 @@ jobs:
 
     - name: Check for format and lint issues
       run: |
-        test -z $(gofmt -s -d -l .) # see https://github.com/golang/go/issues/24230
-        lint="$(golint ./...)" && test -z $lint
+        fmtcode="$(gofmt -s -d -l .)"
+        echo $fmtcode && test -z $fmtcode # see https://github.com/golang/go/issues/24230
+        lintcode="$(golint ./...)"
+        echo $lintcode && test -z $lintcode
 
     - name: Check imports
       run: goimports -l .


### PR DESCRIPTION
The linter was not failing the CI checks with problematic code. This
change uses `test -z` to fail when any linter output is present.